### PR TITLE
ci: Add GH Actions for PR labeller

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -45,3 +45,6 @@ area/security:
 
 area/policy:
   - policy/**
+
+area/base:
+  - base/**

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,47 @@
+# Environment Labels
+env/dev:
+  - clusters/kind/**
+
+# Cluster Labels
+cluster/kind:
+  - clusters/kind/**
+
+cluster/gke-europe:
+  - clusters/gke-europe/**
+
+# Areas
+area/istio:
+  - src/istio/**
+  - base/namespaces/istio-system/**
+  - clusters/*/istio-system/**
+  - clusters/*/istio-operator/**
+  - clusters/**/*istio*.yaml
+
+area/networking:
+  - base/namespaces/networking/**
+  - clusters/*/networking/**
+  - clusters/*/metallb-system/**
+
+area/logging:
+  - base/namespaces/logging/**
+  - clusters/*/logging/**
+
+area/monitoring:
+  - src/kube-prometheus/**
+  - base/namespaces/monitoring/**
+  - clusters/*/monitoring/**
+
+area/kube-system:
+  - base/namespaces/kube-system/**
+  - clusters/*/kube-system/**
+
+area/flux:
+  - base/namespaces/flux/**
+  - clusters/*/flux/**
+
+area/security:
+  - base/security/**
+  - clusters/**/*rbac*.yaml
+
+area/policy:
+  - policy/**

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,11 @@
+name: "Pull Request Labeler"
+on:
+- pull_request
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v2
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Automatically assigning PR labels based on file changes

- `env/<name>` -> Cluster environment (prod/dev/...)
- `cluster/<name>` -> Any changes applied to a specific cluster
- `area/<name>`  -> Anything related to a specific platform area or namespace e.g. networking/istio/logging/monitoring/security
